### PR TITLE
デザインを整えたい

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'simple_form'
 gem 'haml-rails', '~> 2.0'
 gem 'chartkick'
 gem 'rails-i18n', '~> 8.0.0'
+gem 'html2haml'
 
 # for devise
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.1)
+    erubis (2.7.0)
     et-orbi (1.2.11)
       tzinfo
     fugit (1.11.1)
@@ -141,6 +142,11 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    html2haml (2.3.0)
+      erubis (~> 2.7.0)
+      haml (>= 4.0)
+      nokogiri (>= 1.6.0)
+      ruby_parser (~> 3.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -325,6 +331,9 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
+    ruby_parser (3.21.1)
+      racc (~> 1.5)
+      sexp_processor (~> 4.16)
     rubyzip (2.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.31.0)
@@ -333,6 +342,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sexp_processor (4.17.3)
     simple_form (5.3.1)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -420,6 +430,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   haml-rails (~> 2.0)
+  html2haml
   importmap-rails
   jbuilder
   kamal

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
 end

--- a/app/controllers/fitlogs_controller.rb
+++ b/app/controllers/fitlogs_controller.rb
@@ -1,5 +1,5 @@
 class FitlogsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: %i{ index new create edit update destroy }
   def index
     @fitlogs = current_user.fitlogs.all.order(record_at: :desc)
   end

--- a/app/controllers/fitlogs_controller.rb
+++ b/app/controllers/fitlogs_controller.rb
@@ -1,5 +1,5 @@
 class FitlogsController < ApplicationController
-  before_action :authenticate_user!, only: %i{ index new create edit update destroy }
+  before_action :authenticate_user!, only: %i[ index new create edit update destroy ]
   def index
     @fitlogs = current_user.fitlogs.all.order(record_at: :desc)
   end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,5 @@
 class MypagesController < ApplicationController
+  before_action :authenticate_user!, only: %i{ show }
   def show
     # グラフの表示のためにreverse
     @fitlogs = current_user.fitlogs.recent.reverse

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,5 @@
 class MypagesController < ApplicationController
-  before_action :authenticate_user!, only: %i{ show }
+  before_action :authenticate_user!, only: %i[ show ]
   def show
     # グラフの表示のためにreverse
     @fitlogs = current_user.fitlogs.recent.reverse

--- a/app/models/fitlog.rb
+++ b/app/models/fitlog.rb
@@ -1,7 +1,7 @@
 class Fitlog < ApplicationRecord
   belongs_to :user
 
-  validates :weight, presence: true, numericality: { allow_blank: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }
+  validates :weight, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }
   validates :body_fat, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99.9 }, allow_nil: true
   validates :muscle, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }, allow_nil: true
   validates :bmr, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9999.9 }, allow_nil: true

--- a/app/models/fitlog.rb
+++ b/app/models/fitlog.rb
@@ -1,7 +1,7 @@
 class Fitlog < ApplicationRecord
   belongs_to :user
 
-  validates :weight, presence: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }
+  validates :weight, presence: true, numericality: { allow_blank: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }
   validates :body_fat, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 99.9 }, allow_nil: true
   validates :muscle, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 999.9 }, allow_nil: true
   validates :bmr, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9999.9 }, allow_nil: true

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -3,11 +3,11 @@
   = f.error_notification
   = f.full_error :confirmation_token
   .form-inputs
-    = f.input :email,                                                                          |
-      required: true,                                                                          |
-      autofocus: true,                                                                         |
-      value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), |
-      input_html: { autocomplete: "email" }                                                    |
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+      input_html: { autocomplete: "email" }
   .form-actions
     = f.button :submit, "Resend confirmation instructions"
 = render "devise/shared/links"

--- a/app/views/devise/confirmations/new.html.haml
+++ b/app/views/devise/confirmations/new.html.haml
@@ -1,0 +1,13 @@
+%h2 Resend confirmation instructions
+= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  = f.full_error :confirmation_token
+  .form-inputs
+    = f.input :email,                                                                          |
+      required: true,                                                                          |
+      autofocus: true,                                                                         |
+      value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), |
+      input_html: { autocomplete: "email" }                                                    |
+  .form-actions
+    = f.button :submit, "Resend confirmation instructions"
+= render "devise/shared/links"

--- a/app/views/devise/mailer/confirmation_instructions.html.haml
+++ b/app/views/devise/mailer/confirmation_instructions.html.haml
@@ -1,0 +1,4 @@
+%p
+  Welcome #{@email}!
+%p You can confirm your account email through the link below:
+%p= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token)

--- a/app/views/devise/mailer/email_changed.html.haml
+++ b/app/views/devise/mailer/email_changed.html.haml
@@ -1,0 +1,8 @@
+%p
+  Hello #{@email}!
+- if @resource.try(:unconfirmed_email?)
+  %p
+    We're contacting you to notify you that your email is being changed to #{@resource.unconfirmed_email}.
+- else
+  %p
+    We're contacting you to notify you that your email has been changed to #{@resource.email}.

--- a/app/views/devise/mailer/password_change.html.haml
+++ b/app/views/devise/mailer/password_change.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hello #{@resource.email}!
+%p We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.html.haml
+++ b/app/views/devise/mailer/reset_password_instructions.html.haml
@@ -1,0 +1,6 @@
+%p
+  Hello #{@resource.email}!
+%p Someone has requested a link to change your password. You can do this through the link below.
+%p= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token)
+%p If you didn't request this, please ignore this email.
+%p Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.html.haml
+++ b/app/views/devise/mailer/unlock_instructions.html.haml
@@ -1,0 +1,5 @@
+%p
+  Hello #{@resource.email}!
+%p Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+%p Click the link below to unlock your account:
+%p= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token)

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -1,0 +1,19 @@
+%h2 Change your password
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
+  = f.error_notification
+  = f.input :reset_password_token, as: :hidden
+  = f.full_error :reset_password_token
+  .form-inputs
+    = f.input :password,                                                                    |
+      label: "New password",                                                                |
+      required: true,                                                                       |
+      autofocus: true,                                                                      |
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), |
+      input_html: { autocomplete: "new-password" }                                          |
+    = f.input :password_confirmation,              |
+      label: "Confirm your new password",          |
+      required: true,                              |
+      input_html: { autocomplete: "new-password" } |
+  .form-actions
+    = f.button :submit, "Change my password"
+= render "devise/shared/links"

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -4,16 +4,16 @@
   = f.input :reset_password_token, as: :hidden
   = f.full_error :reset_password_token
   .form-inputs
-    = f.input :password,                                                                    |
-      label: "New password",                                                                |
-      required: true,                                                                       |
-      autofocus: true,                                                                      |
-      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), |
-      input_html: { autocomplete: "new-password" }                                          |
-    = f.input :password_confirmation,              |
-      label: "Confirm your new password",          |
-      required: true,                              |
-      input_html: { autocomplete: "new-password" } |
+    = f.input :password,
+      label: "New password",
+      required: true,
+      autofocus: true,
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      label: "Confirm your new password",
+      required: true,
+      input_html: { autocomplete: "new-password" }
   .form-actions
     = f.button :submit, "Change my password"
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -2,10 +2,10 @@
 = simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
   = f.error_notification
   .form-inputs
-    = f.input :email,                       |
-      required: true,                       |
-      autofocus: true,                      |
-      input_html: { autocomplete: "email" } |
+    = f.input :email,
+      required: true,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
   .form-actions
     = f.button :submit, "Send me reset password instructions"
 = render "devise/shared/links"

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -1,0 +1,11 @@
+%h2 Forgot your password?
+= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email,                       |
+      required: true,                       |
+      autofocus: true,                      |
+      input_html: { autocomplete: "email" } |
+  .form-actions
+    = f.button :submit, "Send me reset password instructions"
+= render "devise/shared/links"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,0 +1,26 @@
+%h2
+  Edit #{resource_name.to_s.humanize}
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email, required: true, autofocus: true
+    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+      %p
+        Currently waiting confirmation for: #{resource.unconfirmed_email}
+    = f.input :password,                                     |
+      hint: "leave it blank if you don't want to change it", |
+      required: false,                                       |
+      input_html: { autocomplete: "new-password" }           |
+    = f.input :password_confirmation,              |
+      required: false,                             |
+      input_html: { autocomplete: "new-password" } |
+    = f.input :current_password,                                     |
+      hint: "we need your current password to confirm your changes", |
+      required: true,                                                |
+      input_html: { autocomplete: "current-password" }               |
+  .form-actions
+    = f.button :submit, "Update"
+%h3 Cancel my account
+%div
+  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete}
+= link_to "Back", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -7,17 +7,17 @@
     - if devise_mapping.confirmable? && resource.pending_reconfirmation?
       %p
         Currently waiting confirmation for: #{resource.unconfirmed_email}
-    = f.input :password,                                     |
-      hint: "leave it blank if you don't want to change it", |
-      required: false,                                       |
-      input_html: { autocomplete: "new-password" }           |
-    = f.input :password_confirmation,              |
-      required: false,                             |
-      input_html: { autocomplete: "new-password" } |
-    = f.input :current_password,                                     |
-      hint: "we need your current password to confirm your changes", |
-      required: true,                                                |
-      input_html: { autocomplete: "current-password" }               |
+    = f.input :password,
+      hint: "leave it blank if you don't want to change it",
+      required: false,
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      required: false,
+      input_html: { autocomplete: "new-password" }
+    = f.input :current_password,
+      hint: "we need your current password to confirm your changes",
+      required: true,
+      input_html: { autocomplete: "current-password" }
   .form-actions
     = f.button :submit, "Update"
 %h3 Cancel my account

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,0 +1,18 @@
+%h2 Sign up
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :email,                       |
+      required: true,                       |
+      autofocus: true,                      |
+      input_html: { autocomplete: "email" } |
+    = f.input :password,                                                                    |
+      required: true,                                                                       |
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), |
+      input_html: { autocomplete: "new-password" }                                          |
+    = f.input :password_confirmation,              |
+      required: true,                              |
+      input_html: { autocomplete: "new-password" } |
+  .form-actions
+    = f.button :submit, "Sign up"
+= render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,18 +1,23 @@
-%h2 Sign up
-= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = f.error_notification
-  .form-inputs
-    = f.input :email,                       |
-      required: true,                       |
-      autofocus: true,                      |
-      input_html: { autocomplete: "email" } |
-    = f.input :password,                                                                    |
-      required: true,                                                                       |
-      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length), |
-      input_html: { autocomplete: "new-password" }                                          |
-    = f.input :password_confirmation,              |
-      required: true,                              |
-      input_html: { autocomplete: "new-password" } |
-  .form-actions
-    = f.button :submit, "Sign up"
-= render "devise/shared/links"
+.container.mt-5
+  .row.justify-content-center
+    .col-md-6
+      %h2.text-center.mb-4 登録
+      = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "needs-validation", novalidate: true}) do |f|
+        = f.error_notification
+        .form-inputs
+          = f.input :email,
+            required: true,
+            autofocus: true,
+            input_html: { autocomplete: "email", class: "form-control" }
+          = f.input :password,
+            required: true,
+            hint: ("#{@minimum_password_length} 文字以上で設定出来ます" if @minimum_password_length),
+            input_html: { autocomplete: "new-password", class: "form-control" },
+            label_html: { class: "mt-3" }
+          = f.input :password_confirmation,
+            required: true,
+            input_html: { autocomplete: "new-password", class: "form-control" },
+            label_html: { class: "mt-3" }
+        .d-grid
+          = f.button :submit, "登録", class: "btn btn-primary mt-3"
+      = render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,14 @@
+%h2 Log in
+= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .form-inputs
+    = f.input :email,                       |
+      required: false,                      |
+      autofocus: true,                      |
+      input_html: { autocomplete: "email" } |
+    = f.input :password,                               |
+      required: false,                                 |
+      input_html: { autocomplete: "current-password" } |
+    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+  .form-actions
+    = f.button :submit, "Log in"
+= render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,14 +1,20 @@
-%h2 Log in
-= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .form-inputs
-    = f.input :email,                       |
-      required: false,                      |
-      autofocus: true,                      |
-      input_html: { autocomplete: "email" } |
-    = f.input :password,                               |
-      required: false,                                 |
-      input_html: { autocomplete: "current-password" } |
-    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
-  .form-actions
-    = f.button :submit, "Log in"
-= render "devise/shared/links"
+.container.mt-5
+  .row.justify-content-center
+    .col-md-6
+      %h2.text-center.mb-4 ログイン
+      = simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "needs-validation", novalidate: true}) do |f|
+        .mb-3
+          = f.input :email,
+            required: false,
+            autofocus: true,
+            input_html: { autocomplete: "email", class: "form-control" }
+        .mb-3
+          = f.input :password,
+            required: false,
+            input_html: { autocomplete: "current-password", class: "form-control" }
+        - if devise_mapping.rememberable?
+          .mb-3.form-check
+            = f.input :remember_me, as: :boolean, input_html: {class: "form-check-input"}, label_html: {class: "form-check-label"}
+        .d-grid
+          = f.button :submit, "ログイン", class: "btn btn-primary"
+      = render "devise/shared/links"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,0 +1,9 @@
+- if resource.errors.any?
+  #error_explanation{"data-turbo-cache" => "false"}
+    %h2
+      = I18n.t("errors.messages.not_saved",                 |
+        count: resource.errors.count,                       |
+        resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,0 +1,19 @@
+- if controller_name != 'sessions'
+  = link_to "Log in", new_session_path(resource_name)
+  %br/
+- if devise_mapping.registerable? && controller_name != 'registrations'
+  = link_to "Sign up", new_registration_path(resource_name)
+  %br/
+- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+  = link_to "Forgot your password?", new_password_path(resource_name)
+  %br/
+- if devise_mapping.confirmable? && controller_name != 'confirmations'
+  = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
+  %br/
+- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks'
+  = link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)
+  %br/
+- if devise_mapping.omniauthable?
+  - resource_class.omniauth_providers.each do |provider|
+    = button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }
+    %br/

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,12 +1,13 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  = link_to "ログイン", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
+  = link_to "アカウントを持っていない場合はこちらから登録", new_registration_path(resource_name)
   %br/
-- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
-  %br/
+-# # TODO: Sendgridなど導入したら有効化する
+-# - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+-#   = link_to "Forgot your password?", new_password_path(resource_name)
+-#   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)
   %br/

--- a/app/views/devise/unlocks/new.html.haml
+++ b/app/views/devise/unlocks/new.html.haml
@@ -1,0 +1,12 @@
+%h2 Resend unlock instructions
+= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f|
+  = f.error_notification
+  = f.full_error :unlock_token
+  .form-inputs
+    = f.input :email,                       |
+      required: true,                       |
+      autofocus: true,                      |
+      input_html: { autocomplete: "email" } |
+  .form-actions
+    = f.button :submit, "Resend unlock instructions"
+= render "devise/shared/links"

--- a/app/views/fitlogs/_form.html.haml
+++ b/app/views/fitlogs/_form.html.haml
@@ -1,10 +1,16 @@
 = simple_form_for fitlog do |f|
-  = f.input :record_at, label: '日付', as: :date, input_html: { class: 'mb-2' }
-  = f.input :weight, label: '体重(kg)', input_html: { class: 'form-control' }
-  = f.input :body_fat, label: '体脂肪率(%)', input_html: { class: 'form-control' }
-  = f.input :muscle, label: '筋肉量(kg)', input_html: { class: 'form-control' }
-  = f.input :bmr, label: '基礎代謝量(kcal)', input_html: { class: 'form-control' }
-  = f.input :body_age, label: '体内年齢(歳)', input_html: { class: 'form-control' }
-  = f.input :memo, label: 'メモ', input_html: { class: 'form-control' }
+  = f.input :record_at, label: '日付', as: :date, html5: true, input_html: { class: 'd-block' }
+  .mt-2
+    = f.input :weight, label: '体重(kg)', input_html: { class: 'form-control' }
+  .mt-2
+    = f.input :body_fat, label: '体脂肪率(%)', input_html: { class: 'form-control' }
+  .mt-2
+    = f.input :muscle, label: '筋肉量(kg)', input_html: { class: 'form-control' }
+  .mt-2
+    = f.input :bmr, label: '基礎代謝量(kcal)', input_html: { class: 'form-control' }
+  .mt-2
+    = f.input :body_age, label: '体内年齢(歳)', input_html: { class: 'form-control' }
+  .mt-2
+    = f.input :memo, label: 'メモ', input_html: { class: 'form-control' }
 
   = f.button :submit, '記録する', class: 'btn btn-primary mt-3'

--- a/app/views/fitlogs/edit.html.haml
+++ b/app/views/fitlogs/edit.html.haml
@@ -3,8 +3,6 @@
     %ul
       - @fitlog.errors.full_messages.each do |msg|
         %li= msg
-  .text-end
-    = link_to '記録一覧', fitlogs_path, class: 'btn btn-primary mb-3'
   %h2.text-center 記録編集
 
   = render 'form', fitlog: @fitlog

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -8,9 +8,9 @@
         %ul.navbar-nav
           - if user_signed_in?
             %li.nav-item
-              = link_to 'マイページ', mypage_path, class: 'nav-link'
-            %li.nav-item
               = link_to '記録一覧', fitlogs_path, class: 'nav-link'
+            %li.nav-item
+              = link_to 'マイページ', mypage_path, class: 'nav-link'
             %li.nav-item
               = link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: 'nav-link'
           - else

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,5 +19,6 @@
       %p.notice.alert.alert-primary= flash[:notice]
     - if flash[:alert]
       %p.alert.alert-warning= flash[:alert]
-    = render 'layouts/header'
+    - if user_signed_in?
+      = render 'layouts/header'
     = yield


### PR DESCRIPTION
- ログイン
- 登録
- fitlog登録
- 編集

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced several new user authentication and account management views using Haml, including registration, login, password reset, confirmation, and unlock forms, as well as related email templates.
  - Added new partials for displaying form error messages and shared authentication-related links.

- **Improvements**
  - Updated navigation link order for signed-in users in the header.
  - The header is now only shown to signed-in users.
  - Enhanced the fitlog form layout for better spacing and appearance.
  - Removed a redundant navigation button from the fitlog edit page.

- **Access Control**
  - Adjusted authentication requirements for specific controller actions, ensuring certain pages require user login.
  - Disabled browser version restrictions for accessing the application.

- **Validation**
  - Updated weight validation to allow blank values in fitlog entries.

- **Chores**
  - Added a new gem to support HTML to Haml template conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->