### PR TITLE
記録一覧ページにページネーションを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'haml-rails', '~> 2.0'
 gem 'chartkick'
 gem 'rails-i18n', '~> 8.0.0'
 gem 'html2haml'
+gem 'kaminari'
+gem 'bootstrap5-kaminari-views'
 
 # for devise
 gem 'devise', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,9 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
+    bootstrap5-kaminari-views (0.0.1)
+      kaminari (>= 0.13)
+      rails (>= 3.1)
     brakeman (7.0.2)
       racc
     builder (3.3.0)
@@ -173,6 +176,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -423,6 +438,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
+  bootstrap5-kaminari-views
   brakeman
   capybara
   chartkick
@@ -434,6 +450,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  kaminari
   pg (~> 1.1)
   propshaft
   pry-rails

--- a/app/controllers/fitlogs_controller.rb
+++ b/app/controllers/fitlogs_controller.rb
@@ -1,7 +1,7 @@
 class FitlogsController < ApplicationController
   before_action :authenticate_user!, only: %i[ index new create edit update destroy ]
   def index
-    @fitlogs = current_user.fitlogs.all.order(record_at: :desc)
+    @fitlogs = current_user.fitlogs.all.order(record_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/views/fitlogs/index.html.haml
+++ b/app/views/fitlogs/index.html.haml
@@ -24,5 +24,7 @@
               %td= fitlog.bmr
               %td= fitlog.body_age
               %td{ style: "min-width: 100px;" }= fitlog.memo
+    = paginate @fitlogs , theme: 'bootstrap-5', previous_label: '前のページ', next_label: '次のページ', nav_class: 'pagination justify-content-center'
   - else
     %p 初めての記録をしてみましょう！
+

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/kaminari_ja.yml
+++ b/config/locales/kaminari_ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "..."
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: ""
+          one: "<strong>1-1</strong>/1件中"
+          other: "<strong>1-%{count}</strong>/%{count}件中"
+      more_pages:
+        display_entries: "<strong>%{first}-%{last}</strong>/%{total}件中"


### PR DESCRIPTION
- kaminari
- [bootstrap5-kaminari-views](https://github.com/felipecalvo/bootstrap5-kaminari-views)

- もう少しスタイル調節しても良いかも

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced pagination for the fitlog list, allowing users to view entries page by page.
  - Pagination controls are styled with Bootstrap 5 and include Japanese labels for navigation buttons.
  - Added Japanese translations for all pagination UI elements and helper texts.

- **Chores**
  - Updated dependencies to include pagination and Bootstrap 5 integration.
  - Added a configuration file for pagination settings (all options currently commented out for future use).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->