### PR TITLE
ユーザー削除時は論理削除にしたい

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'bootstrap5-kaminari-views'
 # for devise
 gem 'devise', '~> 4.9'
 
+# for discard
+gem 'discard', '~> 1.4'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri windows ], require: 'debug/prelude'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     dotenv (3.1.8)
     drb (2.2.1)
     ed25519 (1.3.0)
@@ -445,6 +447,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.9)
+  discard (~> 1.4)
   haml-rails (~> 2.0)
   html2haml
   importmap-rails

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,11 @@
 # app/controllers/users_controller.rb
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: %i[ withdraw ]
-  
+
   def withdraw
     current_user.withdraw
 
     sign_out current_user
-    redirect_to new_user_session_path, notice: "退会処理が完了しました。ご利用ありがとうございました。"
+    redirect_to new_user_session_path, notice: '退会処理が完了しました。ご利用ありがとうございました。'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,3 @@
-# app/controllers/users_controller.rb
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: %i[ withdraw ]
 
@@ -7,5 +6,10 @@ class UsersController < ApplicationController
 
     sign_out current_user
     redirect_to new_user_session_path, notice: '退会処理が完了しました。ご利用ありがとうございました。'
+
+  rescue => e
+    # エラーハンドリング
+    logger.error "user_id: #{current_user.id} の退会処理に失敗しました: #{e.message}"
+    redirect_to edit_user_registration_path, alert: "退会処理に失敗しました。"
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,11 @@
+# app/controllers/users_controller.rb
+class UsersController < ApplicationController
+  before_action :authenticate_user!, only: %i[ withdraw ]
+  
+  def withdraw
+    current_user.withdraw
+
+    sign_out current_user
+    redirect_to new_user_session_path, notice: "退会処理が完了しました。ご利用ありがとうございました。"
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,6 @@ class UsersController < ApplicationController
   rescue => e
     # エラーハンドリング
     logger.error "user_id: #{current_user.id} の退会処理に失敗しました: #{e.message}"
-    redirect_to edit_user_registration_path, alert: "退会処理に失敗しました。"
+    redirect_to edit_user_registration_path, alert: '退会処理に失敗しました。'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include Discard::Model
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -6,4 +8,21 @@ class User < ApplicationRecord
 
   has_many :fitlogs, dependent: :destroy
   has_one :profile, dependent: :destroy
+
+  # deviceのメソッドをオーバーライド
+  def active_for_authentication?
+    super && !discarded?
+  end
+
+  def withdraw
+    ActiveRecord::Base.transaction do
+
+      # 関連レコードを削除
+      fitlogs.destroy_all
+      profile&.destroy
+
+      # ユーザーを論理削除
+      discard
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,6 @@ class User < ApplicationRecord
 
   def withdraw
     ActiveRecord::Base.transaction do
-
       # 関連レコードを削除
       fitlogs.destroy_all
       profile&.destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,8 @@ class User < ApplicationRecord
   def withdraw
     ActiveRecord::Base.transaction do
       # 関連レコードを削除
-      fitlogs.destroy_all
-      profile&.destroy
+      fitlogs.destroy_all!
+      profile&.destroy!
 
       # ユーザーを論理削除
       discard

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   def withdraw
     ActiveRecord::Base.transaction do
       # 関連レコードを削除
-      fitlogs.destroy_all!
+      fitlogs.each(&:destroy!)
       profile&.destroy!
 
       # ユーザーを論理削除

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -77,7 +77,7 @@
             %i.bi.bi-shield-exclamation.text-danger.me-3{style: "font-size: 2rem;"}
             .content
               %p.mb-3 アカウントを削除すると、すべてのデータが完全に削除され、復元できなくなります。
-              = button_to registration_path(resource_name), 
+              = button_to users_withdraw_path,
                 data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は取り消せません。" }, 
                 method: :delete, 
                 class: "btn btn-outline-danger" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
+  delete 'users/withdraw', to: 'users#withdraw'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250426070803_add_discarded_at_to_users.rb
+++ b/db/migrate/20250426070803_add_discarded_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_16_122802) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_26_070803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,6 +47,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_16_122802) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
close #29 

- discard gem 導入
- メールアドレスはマスキングしてもいいかも

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a soft deletion (withdrawal) feature for user accounts, allowing users to withdraw their accounts while preserving data integrity.
  - Added a dedicated withdrawal button that routes account deletion requests to a new withdrawal endpoint.
- **Bug Fixes**
  - Ensured that withdrawn (soft-deleted) users cannot log in.
- **Chores**
  - Updated database schema to support soft deletion of user accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->